### PR TITLE
Add linguist override for .vb files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.vb    linguist-language=vba


### PR DESCRIPTION
I noticed that you use the .vb extension for some of your VBA code. However, this extension is marked by Linguist as a VB.NET extension. To fix that, I've added an override, so the repo can be properly marked as a VBA repo (in the language breakdown and in searches).